### PR TITLE
Fix github action cache

### DIFF
--- a/.github/workflows/pr-docs-check.yml
+++ b/.github/workflows/pr-docs-check.yml
@@ -34,9 +34,9 @@ jobs:
             sudo apt install -y wget
             wget https://github.com/doxygen/doxygen/releases/download/Release_1_11_0/doxygen-1.11.0.linux.bin.tar.gz
             tar -xzf doxygen-1.11.0.linux.bin.tar.gz
+            rm doxygen-1.11.0.linux.bin.tar.gz
           fi
-          sudo mv doxygen-1.11.0/bin/* /usr/local/bin/
-          rm -rf doxygen-1.11.0*
+          sudo cp doxygen-1.11.0/bin/* /usr/local/bin/
 
       - name: Generate Doxygen Documentation and Display Warnings Only
         run: |


### PR DESCRIPTION
Make a copy instead of moving doxygen 1.11, dont delete cache, remove archive file.