### PR TITLE
Add targets and subdirectory rules for kernel, utils, and addons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,13 @@ error:
 	@exit 0
 endif
 
+# Separate targets for kernel, utils, and addons
+kernel: kernel_subdirs
+
+utils: utils_subdirs
+
+addons: kernel addons_subdirs
+
 all: subdirs
 
 clean: clean_subdirs
@@ -54,5 +61,26 @@ all_auto_kos_base:
 
 clean_auto_kos_base:
 	$(MAKE) clean KOS_BASE=$(CURDIR)
+
+# Subdirectory rules
+subdirs:
+	@for dir in $(SUBDIRS); do \
+		$(MAKE) -C $$dir; \
+	done
+
+clean_subdirs:
+	@for dir in $(SUBDIRS); do \
+		$(MAKE) -C $$dir clean; \
+	done
+
+# Specific rules for kernel, utils, and addons
+kernel_subdirs:
+	$(MAKE) -C kernel
+
+utils_subdirs:
+	$(MAKE) -C utils
+
+addons_subdirs:
+	$(MAKE) -C addons
 
 include $(KOS_BASE)/Makefile.rules


### PR DESCRIPTION
Added functionality to allow selective builds, enabling kernel, util, addons changes to be compiled without rebuilding the entire project.