### PR TITLE
Remove lwip references

### DIFF
--- a/examples/dreamcast/mruby/dreampresent/main.c
+++ b/examples/dreamcast/mruby/dreampresent/main.c
@@ -38,7 +38,7 @@
    INIT_NONE         -- don't do any auto init
    INIT_IRQ          -- knable IRQs
    INIT_THD_PREEMPT  -- Enable pre-emptive threading
-   INIT_NET          -- Enable networking (doesn't imply lwIP!)
+   INIT_NET          -- Enable networking
    INIT_MALLOCSTATS  -- Enable a call to malloc_stats() right before shutdown
 
    You can OR any or all of those together. If you want to start out with

--- a/examples/dreamcast/mruby/mrbtris/main.c
+++ b/examples/dreamcast/mruby/mrbtris/main.c
@@ -38,7 +38,7 @@
    INIT_NONE         -- don't do any auto init
    INIT_IRQ          -- knable IRQs
    INIT_THD_PREEMPT  -- Enable pre-emptive threading
-   INIT_NET          -- Enable networking (doesn't imply lwIP!)
+   INIT_NET          -- Enable networking
    INIT_MALLOCSTATS  -- Enable a call to malloc_stats() right before shutdown
 
    You can OR any or all of those together. If you want to start out with

--- a/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
+++ b/kernel/arch/dreamcast/hardware/network/broadband_adapter.c
@@ -49,9 +49,7 @@
 #define DMA_THRESHOLD 128 // looks like a good value
 
 /* Since callbacks will be running with interrupts enabled,
-   it might be a good idea to protect bba_tx with a semaphore from inside.
-   I'm not sure lwip needs that, but dcplaya does when using both lwip and its
-   own dcload syscalls emulation.*/
+   it might be a good idea to protect bba_tx with a semaphore from inside. */
 #define TX_SEMA
 
 /* If this is defined, the dma buffer will be located in P2 area, and no call to

--- a/kernel/arch/dreamcast/include/dc/fs_dcload.h
+++ b/kernel/arch/dreamcast/include/dc/fs_dcload.h
@@ -143,9 +143,6 @@ void fs_dcload_init_console(void);
 void fs_dcload_init(void);
 void fs_dcload_shutdown(void);
 
-/* Init func for dcload-ip + lwIP */
-int fs_dcload_init_lwip(void *p);
-
 /* \endcond */
 
 /** @} */

--- a/kernel/libc/koslib/getaddrinfo.c
+++ b/kernel/libc/koslib/getaddrinfo.c
@@ -48,9 +48,6 @@
    This performs a simple DNS A-record query. It hasn't been tested extensively
    but so far it seems to work fine.
 
-   This relies on the really sketchy UDP support in the KOS lwIP port, so it
-   can be cleaned up later once that's improved.
-
    We really need to be setting errno in here too...
  */
 


### PR DESCRIPTION
Removed unused lwip code/references where unneeded. 

lwIP used to be provided as an alternate TCP/IP stack for the BBA and
Lan Adapters, however it was removed from the kos-ports tree as it has
been deprecated by the built-in network stack.

Takes care of issue #27.