### PR TITLE
Added rewinddir support to dcload

### DIFF
--- a/kernel/arch/dreamcast/fs/fs_dcload.c
+++ b/kernel/arch/dreamcast/fs/fs_dcload.c
@@ -401,6 +401,19 @@ static int dcload_fcntl(void *h, int cmd, va_list ap) {
     return rv;
 }
 
+static int dcload_rewinddir(void *h) {
+    int rv = -1;
+    uint32_t hnd = (uint32_t)h;
+
+    spinlock_lock(&dcload_lock);
+
+    rv = dclsc(DCLOAD_REWINDDIR, hnd);
+
+    spinlock_unlock(&dcload_lock);
+
+    return rv;
+}
+
 /* Pull all that together */
 static vfs_handler_t vh = {
     /* Name handler */
@@ -439,7 +452,7 @@ static vfs_handler_t vh = {
     NULL,               /* tell64 */
     NULL,               /* total64 */
     NULL,               /* readlink */
-    NULL,               /* rewinddir */
+    dcload_rewinddir,
     NULL                /* fstat */
 };
 

--- a/kernel/arch/dreamcast/include/dc/fs_dcload.h
+++ b/kernel/arch/dreamcast/include/dc/fs_dcload.h
@@ -76,6 +76,7 @@ extern int dcload_type;
 #define DCLOAD_READDIR      18
 #define DCLOAD_GETHOSTINFO  19
 #define DCLOAD_GDBPACKET    20
+#define DCLOAD_REWINDDIR    21
 
 /* dcload syscall function */
 int dcloadsyscall(uint32_t syscall, ...);


### PR DESCRIPTION
Actually dcload for both serial and IP already contained support for rewinddir.  It just wasn't supported on the KOS or dctool(HOST) side.  This changes that for KOS.