### PR TITLE
Add GHA to generate toolchains

### DIFF
--- a/.github/workflows/gen-toolchains.yaml
+++ b/.github/workflows/gen-toolchains.yaml
@@ -1,0 +1,58 @@
+name: Generate Toolchain Docker Images
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - utils/dc-chain/scripts/**
+      - utils/dc-chain/patches/**
+      - utils/dc-chain/profiles/**
+      - utils/dc-chain/Makefile
+      - utils/dc-chain/Makefile.default.cfg
+      - utils/dc-chain/docker/Dockerfile
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        version:
+          - { tag: "legacy", dc_chain: "legacy" }
+          - { tag: "stable", dc_chain: "stable" }
+          - { tag: "dev", dc_chain: "dev" }
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and Push Docker Image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        dockerfile: utils/dc-chain/docker/Dockerfile
+        push: true
+        tags: ghcr.io/${{ github.actor }}/dcchain:${{ matrix.version.tag }}
+        build-args: |
+          dc_chain=${{ matrix.version.dc_chain }}
+          makejobs=8
+          enable_objc=0
+          enable_objcpp=0
+        no-cache: true
+
+    - name: Save Build Logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-logs-${{ matrix.version.tag }}
+        path: /tmp/build-logs


### PR DESCRIPTION
Toolchain Docker images will now be generated on push to master for 3 different versions of GCC.