### PR TITLE
Update gcc profiles

### DIFF
--- a/utils/dc-chain/Makefile.default.cfg
+++ b/utils/dc-chain/Makefile.default.cfg
@@ -7,19 +7,16 @@
 
 # Choose a toolchain profile from the following available options:
 # No longer supported upstream:
-# - 9.3.0-legacy: Former 'stable' option, based on GCC 9.3.0 and Newlib 3.3.0.
-# - 9.5.0-winxp:  Most recent versions of tools which run on Windows XP.
 # - 10.5.0:       Last release in the GCC 10 series, released 2023-07-07.
 # - 11.5.0:       Last release in the GCC 11 series, released 2024-07-19.
 # Supported upstream:
 # - 12.4.0:       Latest release in the GCC 12 series, released 2024-06-20.
-# - stable:       Tested stable; based on GCC 13.2.0, released 2023-07-27.
-# - 13.3.0:       Latest release in the GCC 13 series, released 2024-05-21.
-# - 14.2.0:       Latest release in the GCC 14 series, released 2024-08-01.
+# - legacy:       Tested legacy; based on GCC 13.3.0, released 2024-05-21.
+# - stable:       Tested stable; based on GCC 14.2.0, released 2024-08-01.
 # Development versions:
 # - 13.3.1-dev    Bleeding edge GCC 13 series from git.
 # - 14.2.1-dev    Bleeding edge GCC 14 series from git.
-# - 15.0.0-dev    Bleeding edge GCC 15 series from git.
+# - dev:          Bleeding edge GCC 15 series(15.0.0-dev) from git.
 # - gccrs-dev:    GCC fork for development of the GCCRS Rust compiler.
 # - rustc-dev:    GCC fork for development of the libgccjit rustc GCC codegen.
 # If unsure, select stable. See README.md for more detailed descriptions.

--- a/utils/dc-chain/profiles/profile.dev.mk
+++ b/utils/dc-chain/profiles/profile.dev.mk
@@ -1,11 +1,23 @@
 # Sega Dreamcast Toolchains Maker (dc-chain)
 # This file is part of KallistiOS.
 
+###############################################################################
+###############################################################################
+### THIS CONFIG IS FOR AN EXPERIMENTAL VERSION OF GCC!
+## THERE ARE NO KNOWN ISSUES BUILDING THIS VERSION as of 2024-07-09.
+###############################################################################
+###############################################################################
+
 # Toolchain versions for SH
 sh_binutils_ver=2.43
-sh_gcc_ver=14.2.0
+sh_gcc_ver=15.0.0
 newlib_ver=4.4.0.20231231
 gdb_ver=15.1
+
+# Overide SH toolchain download type
+sh_gcc_download_type=git
+sh_gcc_git_repo=git://gcc.gnu.org/git/gcc.git
+sh_gcc_git_branch=master
 
 # Toolchain for ARM
 # The ARM version of gcc/binutils is separated as support for the ARM7DI core

--- a/utils/dc-chain/profiles/profile.legacy.mk
+++ b/utils/dc-chain/profiles/profile.legacy.mk
@@ -3,7 +3,7 @@
 
 # Toolchain versions for SH
 sh_binutils_ver=2.43
-sh_gcc_ver=14.2.0
+sh_gcc_ver=13.3.0
 newlib_ver=4.4.0.20231231
 gdb_ver=15.1
 


### PR DESCRIPTION
Added two new profiles for legacy and dev to make GHA easier.  Updated stable to 14.2.0