### PR TITLE
Add distclean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ SUBDIRS = utils kernel addons # examples
 # Detect a non-working or missing environ.sh file.
 ifndef KOS_BASE
 error:
-	@echo You don\'t seem to have a working  environ.sh file. Please take a look at
+	@echo You don\'t seem to have a working environ.sh.master file. Please take a look at
 	@echo doc/README for more info.
 	@exit 0
 endif

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ clean: clean_subdirs
 distclean: clean
 	-rm -f lib/$(KOS_ARCH)/*
 	-rm -f addons/lib/$(KOS_ARCH)/*
+	$(MAKE) -C utils distclean
 
 docs:
 	doxygen $(KOS_BASE)/doc/Doxyfile

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -73,7 +73,12 @@ $(patsubst %, _dir_%, $(SUBDIRS)):
 clean_subdirs: $(patsubst %, _clean_dir_%, $(SUBDIRS))
 
 $(patsubst %, _clean_dir_%, $(SUBDIRS)):
-	$(MAKE) -C $(patsubst _clean_dir_%, %, $@) clean
+	-$(MAKE) -C $(patsubst _clean_dir_%, %, $@) clean
+
+distclean_subdirs: $(patsubst %, _distclean_dir_%, $(SUBDIRS))
+
+$(patsubst %, _distclean_dir_%, $(SUBDIRS)):
+	-$(MAKE) -C $(patsubst _distclean_dir_%, %, $@) distclean
 
 # Define KOS_ROMDISK_DIR in your Makefile if you want these two handy rules.
 ifdef KOS_ROMDISK_DIR

--- a/addons/Makefile.prefab
+++ b/addons/Makefile.prefab
@@ -23,8 +23,8 @@ linklib: $(OBJS) $(LIB_OBJS)
 	$(KOS_AR) rcs $(KOS_BASE)/addons/lib/$(KOS_ARCH)/$(TARGET) $(OBJS) $(LIB_OBJS)
 
 clean: defaultclean
-         
+
 defaultclean: clean_subdirs
-	-rm -f $(OBJS) $(KOS_BASE)/addons/lib/$(KOS_ARCH)/$(TARGET) $(LOCAL_CLEAN)
+	-rm -f $(OBJS) $(LOCAL_CLEAN)
 
 include $(KOS_BASE)/Makefile.rules

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -15,4 +15,6 @@ all: subdirs
 
 clean: clean_subdirs
 
+distclean: distclean_subdirs
+
 include $(KOS_BASE)/Makefile.rules

--- a/utils/bin2c/Makefile
+++ b/utils/bin2c/Makefile
@@ -6,5 +6,5 @@ all: bin2c
 bin2c: bin2c.c
 	gcc -o $@ $^
 
-clean:
+distclean:
 	-rm -f bin2c

--- a/utils/bincnv/Makefile
+++ b/utils/bincnv/Makefile
@@ -9,5 +9,5 @@ all: bincnv
 bincnv: bincnv.c
 	gcc -o bincnv bincnv.c
 
-clean:
+distclean:
 	-rm -f bincnv

--- a/utils/dcbumpgen/Makefile
+++ b/utils/dcbumpgen/Makefile
@@ -10,5 +10,8 @@ dcbumpgen: dcbumpgen.o get_image.o get_image_jpg.o get_image_png.o readpng.o
 	$(CC) -o $@ $+ $(LDFLAGS)
 
 clean:
-	rm -f dcbumpgen *.o
+	rm -f *.o
+
+distclean: clean
+	rm -f dcbumpgen
 

--- a/utils/font2txf/Makefile
+++ b/utils/font2txf/Makefile
@@ -8,3 +8,7 @@ all:
 clean:
 	@cd ./src; \
 	$(MAKE) clean
+
+distclean: clean
+	@cd ./src; \
+	$(MAKE) distclean

--- a/utils/font2txf/src/Makefile
+++ b/utils/font2txf/src/Makefile
@@ -86,13 +86,16 @@ all: $(TARGET)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(TARGET): $(OBJECTS)
-	$(CXX) $(CXXFLAGS) -o $(OUTPUT) $(OBJECTS) $(LDFLAGS) $(LDLIBS)	
+	$(CXX) $(CXXFLAGS) -o $(OUTPUT) $(OBJECTS) $(LDFLAGS) $(LDLIBS)
 
 install: $(TARGET)
 	mkdir -p $(INSTALLDIR)
 	$(STRIP) $(OUTPUT)
-	mv $(OUTPUT) $(INSTALLDIR)	
+	mv $(OUTPUT) $(INSTALLDIR)
 
-.PHONY: clean
+.PHONY: clean distclean
 clean:
-	-rm -f $(OUTPUT) *.o
+	-rm -f *.o
+
+distclean: clean
+	-rm -f $(OUTPUT)

--- a/utils/genromfs/Makefile
+++ b/utils/genromfs/Makefile
@@ -14,7 +14,10 @@ all: genromfs
 genromfs: genromfs.o
 
 clean:
-	rm -f genromfs *.o
+	rm -f *.o
+
+distclean: clean
+	rm -f genromfs
 
 install: all install-bin install-man
 

--- a/utils/gentexfont/Makefile
+++ b/utils/gentexfont/Makefile
@@ -8,5 +8,8 @@ all: gentexfont
 gentexfont: gentexfont.o
 
 clean:
-	rm -f gentexfont *.o
+	rm -f *.o
+
+distclean: clean
+	rm -f gentexfont
 

--- a/utils/isotest/Makefile
+++ b/utils/isotest/Makefile
@@ -9,6 +9,5 @@ all: isotest
 isotest: isotest.c
 	gcc -g -o isotest isotest.c
 
-clean:
+distclean:
 	-rm -f isotest
-

--- a/utils/kmgenc/Makefile
+++ b/utils/kmgenc/Makefile
@@ -10,5 +10,8 @@ kmgenc: kmgenc.o get_image.o get_image_jpg.o get_image_png.o readpng.o
 	$(CC) -o $@ $+ $(LDFLAGS)
 
 clean:
-	rm -f kmgenc *.o
+	rm -f *.o
+
+distclean: clean
+	rm -f kmgenc
 

--- a/utils/makeip/Makefile
+++ b/utils/makeip/Makefile
@@ -8,3 +8,6 @@ all:
 clean:
 	@cd ./src; \
 	$(MAKE) clean
+
+distclean: clean
+	-rm -f makeip

--- a/utils/makeip/src/Makefile
+++ b/utils/makeip/src/Makefile
@@ -29,6 +29,9 @@ install:
 	mkdir -p $(INSTALLDIR)
 	mv $(OUTPUT) $(INSTALLDIR)
 
-.PHONY: clean
+.PHONY: clean distclean
 clean:
-	-rm -f $(OUTPUT) *.o
+	-rm -f *.o
+
+distclean: clean
+	-rm -f $(OUTPUT)

--- a/utils/makejitter/Makefile
+++ b/utils/makejitter/Makefile
@@ -5,7 +5,10 @@ CFLAGS = -O2 -Wall -I../../../kos-ports/include #-g#
 makejitter: makejitter.o
 
 clean:
-	rm -f makejitter jitter_table.h *.o
+	rm -f jitter_table.h *.o
+
+distclean: clean
+	rm -f makejitter
 
 install: all install-bin
 

--- a/utils/naomibintool/Makefile
+++ b/utils/naomibintool/Makefile
@@ -10,5 +10,5 @@ naomibintool: naomibintool.c
 #	$(CC) -DNO_LIBELF -o naomibintool naomibintool.c
 	$(CC) -o naomibintool naomibintool.c -lelf
 
-clean:
+distclean:
 	-rm -f naomibintool

--- a/utils/naominetboot/Makefile
+++ b/utils/naominetboot/Makefile
@@ -9,5 +9,5 @@ all: naominetboot
 naominetboot: naominetboot.c
 	$(CC) -o naominetboot naominetboot.c
 
-clean:
+distclean:
 	-rm -f naominetboot

--- a/utils/pvrtex/Makefile
+++ b/utils/pvrtex/Makefile
@@ -35,7 +35,10 @@ $(TARGET): $(OBJS)
 main.o: main.c info/options.h info/examples.h
 
 clean:
-	rm -f $(TARGET) $(OBJS) README
+	rm -f $(OBJS) README
+
+distclean: clean
+	rm -f $(TARGET)
 
 README: readme_unformatted.txt
 	fmt -s readme_unformatted.txt > README

--- a/utils/rdtest/Makefile
+++ b/utils/rdtest/Makefile
@@ -9,6 +9,6 @@ all: rdtest
 rdtest: rdtest.c
 	gcc -g -o rdtest rdtest.c
 
-clean:
+distclean:
 	-rm -f rdtest
 

--- a/utils/scramble/Makefile
+++ b/utils/scramble/Makefile
@@ -5,6 +5,6 @@ all: scramble
 scramble:
 	cc -o scramble scramble.c
 
-clean:
+distclean:
 	-rm -f scramble
 

--- a/utils/vqenc/Makefile
+++ b/utils/vqenc/Makefile
@@ -10,7 +10,10 @@ vqenc: vqenc.o get_image.o get_image_jpg.o get_image_png.o readpng.o
 	$(CC) -o $@ $+ $(LDFLAGS)
 
 clean:
-	rm -f vqenc *.o
+	rm -f *.o
 
-install: all 
+distclean: clean
+	rm -f vqenc
+
+install: all
 	install -m 755 vqenc /usr/bin

--- a/utils/wav2adpcm/Makefile
+++ b/utils/wav2adpcm/Makefile
@@ -7,4 +7,7 @@ CFLAGS = -O2 -Wall #-g#
 all: wav2adpcm
 
 clean:
-	-rm -f wav2adpcm.o wav2adpcm
+	-rm -f wav2adpcm.o
+
+distclean: clean
+	-rm -f wav2adpcm


### PR DESCRIPTION
This PR addresses an inconsistency in the cleanup behavior of make clean and make distclean within the KallistiOS directory. Previously, running make clean would remove addon libraries but leave the libraries for Kallisti and exports untouched. To align with the intended behavior, this PR makes the following changes:

1. Refines make clean:
- make clean now only removes object files from the utils directories and avoids cleaning addon libraries.

2. Extends make distclean:
- make distclean has been updated to include cleanup of binaries in the utils directories, ensuring a complete cleanup when needed.

These changes provide a clear separation between make clean (removes intermediate build artifacts) and make distclean (performs a deeper cleanup of all generated files, including binaries).