### PR TITLE
Add kos dockerfile

### DIFF
--- a/.github/docker/entrypoint.sh
+++ b/.github/docker/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Source the environment setup script
+if [ -f "/opt/toolchains/dc/kos/environ.sh.master" ]; then
+    source /opt/toolchains/dc/kos/environ.sh.master
+fi
+
+# Execute the provided command or fall back to bash
+if [ "$#" -eq 0 ]; then
+    # No command provided, start an interactive shell
+    exec /bin/bash
+else
+    # Execute the provided command
+    exec "$@"
+fi

--- a/.github/docker/kos-Dockerfile
+++ b/.github/docker/kos-Dockerfile
@@ -1,0 +1,31 @@
+# Define an argument for the tag
+ARG BASE_TAG=14.2-stable
+
+# Use the static portion of the base image combined with the tag
+FROM ghcr.io/kallistiosunchained/dc-toolchain:${BASE_TAG}
+
+# Metadata
+LABEL maintainer="KallistiOS (Unchained)"
+
+ARG REPO_BRANCH="master"
+
+# Clone KOS & kos-ports
+RUN git clone --depth=1 --branch ${REPO_BRANCH} https://github.com/KallistiOSUnchained/KallistiOS.git /opt/toolchains/dc/kos && \
+    git clone --depth=1 --branch ${REPO_BRANCH} https://github.com/KallistiOSUnchained/kos-ports.git /opt/toolchains/dc/kos-ports
+
+# Set default working directory
+WORKDIR /opt/toolchains/dc/kos
+
+# Compile KOS, kos-ports, and the examples
+RUN source environ.sh.master && \
+    make && \
+    make clean && \
+    make kos-ports_all
+
+# Setup auto sourcing for (non)interactice shells
+COPY entrypoint.sh /opt/toolchains/dc/kos/entrypoint.sh
+RUN chmod 755 /opt/toolchains/dc/kos/entrypoint.sh
+ENTRYPOINT ["/opt/toolchains/dc/kos/entrypoint.sh"]
+
+# If run with no parameters just start bash
+CMD ["/bin/bash"]


### PR DESCRIPTION
Add a kos dockerfile so we can create different kos-toolchain docker images for each version of GCC (legacy, stable, dev).