### PR TITLE
KOSP => KOSU

### DIFF
--- a/kernel/arch/dreamcast/include/arch/byteorder.h
+++ b/kernel/arch/dreamcast/include/arch/byteorder.h
@@ -25,8 +25,6 @@
 #include <sys/cdefs.h>
 __BEGIN_DECLS
 
-#include <sys/_types.h>
-
 #ifdef BYTE_ORDER
 /* If we've included <arch/types.h>, this might already be defined... */
 #undef BYTE_ORDER
@@ -52,7 +50,7 @@ __BEGIN_DECLS
     \return             The swapped value.
 */
 #define arch_swap16(x) ({ \
-    uint16 __x = (x); \
+    uint16_t __x = (x); \
     __asm__ __volatile__("swap.b %0, %0" : "=r" (__x) : "0" (__x)); \
     __x; \
 })
@@ -67,7 +65,7 @@ __BEGIN_DECLS
     \return             The swapped value.
 */
 #define arch_swap32(x) ({ \
-    uint32 __x = (x); \
+    uint32_t __x = (x); \
     __asm__ __volatile__("swap.b %0, %0\n\t" \
                          "swap.w %0, %0\n\t" \
                          "swap.b %0, %0\n\t" : "=r"(__x) : "0" (__x)); \

--- a/kernel/arch/dreamcast/include/dc/biosfont.h
+++ b/kernel/arch/dreamcast/include/dc/biosfont.h
@@ -55,6 +55,7 @@ __BEGIN_DECLS
 
 /** \brief Number of bytes to represent a single character within the BIOS font. */
 #define BFONT_BYTES_PER_CHAR        (BFONT_THIN_WIDTH * BFONT_HEIGHT / 8)
+#define BFONT_BYTES_PER_WIDE_CHAR   (BFONT_WIDE_WIDTH * BFONT_HEIGHT / 8)
 
 /** \defgroup bfont_indicies Structure
     \brief                   Structure of the Bios Font
@@ -76,14 +77,15 @@ __BEGIN_DECLS
 /** \brief Start of JISX-0208 Rows 1-7 in Font Block */   
 #define BFONT_JISX_0208_ROW1        BFONT_WIDE_START
 /** \brief Start of JISX-0208 Row 16-47 (Start of Level 1) in Font Block */   
-#define BFONT_JISX_0208_ROW16       (BFONT_WIDE_START + (658 * BFONT_BYTES_PER_CHAR))
+#define BFONT_JISX_0208_ROW16       (BFONT_WIDE_START + (658 * BFONT_BYTES_PER_WIDE_CHAR))
 /** \brief JISX-0208 Row 48-84 (Start of Level 2) in Font Block */
-#define BFONT_JISX_0208_ROW48       (BFONT_JISX_0208_ROW16 + ((32 * JISX_0208_ROW_SIZE) * BFONT_BYTES_PER_CHAR))
+#define BFONT_JISX_0208_ROW48       (BFONT_JISX_0208_ROW16 + ((32 * JISX_0208_ROW_SIZE) * BFONT_BYTES_PER_WIDE_CHAR))
 
 /** \brief Start of DC Specific Characters in Font Block */
-#define BFONT_DREAMCAST_SPECIFIC    (BFONT_WIDE_START + (7056 * BFONT_BYTES_PER_CHAR))
+#define BFONT_DREAMCAST_SPECIFIC    (BFONT_WIDE_START + (7056 * BFONT_BYTES_PER_WIDE_CHAR))
+
 /** \brief Takes a DC-specific icon index and returns a character offset. */
-#define BFONT_DC_ICON(offset)       (BFONT_DREAMCAST_SPECIFIC + ((offset) * BFONT_BYTES_PER_CHAR))
+#define BFONT_DC_ICON(offset)       (BFONT_DREAMCAST_SPECIFIC + ((offset) * BFONT_BYTES_PER_WIDE_CHAR))
 
 /** \defgroup bfont_dc_indices Dreamcast-Specific 
     \brief    Dreamcast-specific BIOS icon offsets.
@@ -114,7 +116,7 @@ __BEGIN_DECLS
 /** @} */
 
 #define BFONT_ICON_DIMEN                 32    /**< \brief Dimension of vmu icons */
-#define BFONT_VMU_DREAMCAST_SPECIFIC     (BFONT_DREAMCAST_SPECIFIC+(22 * BFONT_BYTES_PER_CHAR))
+#define BFONT_VMU_DREAMCAST_SPECIFIC     (BFONT_DREAMCAST_SPECIFIC+(22 * BFONT_BYTES_PER_WIDE_CHAR))
 /** @} */
 
 /** \brief Builtin VMU Icons

--- a/kernel/libc/koslib/scandir.c
+++ b/kernel/libc/koslib/scandir.c
@@ -48,7 +48,7 @@ static int push_back(struct dirent ***list, int *size, int *capacity,
         *list = realloc(*list, *capacity * sizeof(struct dirent*));
 
         /* Handle out-of-memory in case realloc() failed. */
-        if(!list)
+        if(!*list)
             goto out_of_memory;
         else
             list_tmp = list;

--- a/kernel/thread/genwait.c
+++ b/kernel/thread/genwait.c
@@ -45,15 +45,15 @@ static void tq_insert(kthread_t * thd) {
 
     /* Search for its place; note that new threads will be placed at
        the end of a group with the same timeout. */
-    TAILQ_FOREACH(t, &timer_queue, timerq) {
-        if(thd->wait_timeout < t->wait_timeout) {
-            TAILQ_INSERT_BEFORE(t, thd, timerq);
+    TAILQ_FOREACH_REVERSE(t, &timer_queue, slpquehead, timerq) {
+        if(thd->wait_timeout >= t->wait_timeout) {
+            TAILQ_INSERT_AFTER(&timer_queue, t, thd, timerq);
             return;
         }
     }
 
-    /* Couldn't find anything scheduled later, put this at the end. */
-    TAILQ_INSERT_TAIL(&timer_queue, thd, timerq);
+    /* Couldn't find anything scheduled earlier, put this at the start. */
+    TAILQ_INSERT_HEAD(&timer_queue, thd, timerq);
 }
 
 /* Internal function to remove a thread from the timer queue. */


### PR DESCRIPTION
* Update byteorder to not rely on arch types
* Fix wide character support
* Correct out-of-memory test in scandir
* Reverse the order of searching the genwait queue