### PR TITLE
embed: Add support for embedding application name via KOS_APP_NAME Ma…

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -92,6 +92,20 @@ romdisk.o: romdisk.img
 	rm romdisk_tmp.c romdisk_tmp.o
 endif
 
+# Add the application name to the binary
+ifdef KOS_APP_NAME
+OBJS += app_name.o
+
+app_name.bin:
+	@printf "%s\0" "$(KOS_APP_NAME)" > app_name.bin
+
+app_name.o: app_name.bin
+	$(KOS_BASE)/utils/bin2c/bin2c app_name.bin app_name_tmp.c app_name
+	$(KOS_CC) $(KOS_CFLAGS) -c app_name_tmp.c -o app_name_tmp.o
+	$(KOS_CC) -o app_name.o -r app_name_tmp.o $(KOS_LIB_PATHS)
+	rm app_name.bin app_name_tmp.c app_name_tmp.o
+endif
+
 define KOS_GCCVER_MIN_CHECK
 $(shell \
 	awk 'BEGIN { \

--- a/kernel/arch/dreamcast/include/arch/arch.h
+++ b/kernel/arch/dreamcast/include/arch/arch.h
@@ -32,6 +32,18 @@ __BEGIN_DECLS
     @{
 */
 
+/** \brief  Returns the embedded application name.
+    \ingroup arch
+
+    This returns the app name string embedded at build time via the 
+    KOS_APP_NAME Makefile variable. If no embedded name is present,
+    it falls back to "prog.elf".
+
+    \return                 A pointer to a null-terminated string 
+                            representing the application name.
+*/
+const char *get_app_name(void);
+
 /** \brief  Top of memory available, depending on memory size. */
 #ifdef __KOS_GCC_32MB__
 extern uint32 _arch_mem_top;

--- a/kernel/arch/dreamcast/kernel/init.c
+++ b/kernel/arch/dreamcast/kernel/init.c
@@ -259,6 +259,14 @@ void  __weak arch_auto_shutdown(void) {
     rtc_shutdown();
 }
 
+/* Embedded string and size from KOS_APP_NAME Makefile.Rules variable */
+extern unsigned char __weak app_name_data[];
+extern int __weak app_name_size;
+
+const char *get_app_name(void) {
+    return (&app_name_data && app_name_size > 0) ? (const char *)app_name_data : "prog.elf";
+}
+
 /* Strongly defined in gcrt1.S and linked when compiling with -pg */
 void __weak gprof_init(void) { }
 

--- a/kernel/arch/dreamcast/kernel/irq.c
+++ b/kernel/arch/dreamcast/kernel/irq.c
@@ -165,7 +165,7 @@ static void irq_dump_regs(int code, irq_t evt) {
         /* Construct template message only if either PC/PR address is valid */
         if(valid_pc || valid_pr) {
             dbglog(DBG_DEAD, "Use this template terminal command to help"
-                " diagnose:\n\n\t$KOS_ADDR2LINE -f -C -i -e prog.elf");
+                " diagnose:\n\n\t$KOS_ADDR2LINE -f -C -i -e %s", get_app_name());
             
             if(valid_pc)
                 dbglog(DBG_DEAD, " %08lx", irq_srt_addr->pc);


### PR DESCRIPTION
…kefile variable

- Introduced build logic to embed a null-terminated application name string using bin2c when APP_NAME is defined.
- Added weakly-linked symbols `app_name_data` and `app_name_size` to access the embedded name at runtime without requiring the symbol to be present.
- Implemented `get_app_name()` helper for safe access with fallback to "prog.elf".
- Updated exception output to reference the embedded name in diagnostic messages.